### PR TITLE
Return a `Result<(), CannotUseAbility>` instead of a bool

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "leafwing_abilities"
 description = "A convenient, well-tested ability management suite. Built for the Bevy game engine."
-version = "0.1.1"
+version = "0.2.0"
 authors = ["Leafwing Studios"]
 homepage = "https://leafwing-studios.com/"
 repository = "https://github.com/leafwing-studios/leafwing-input-manager"
@@ -25,7 +25,7 @@ bevy = {version = "0.8", default-features = false, features = ["serialize", "bev
 serde = {version = "1.0", features = ["derive"]}
 leafwing-input-manager = "0.6"
 
-leafwing_abilities_macros = { path = "macros", version = "0.1" }
+leafwing_abilities_macros = { path = "macros", version = "0.2" }
 thiserror = "1.0.37"
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ serde = {version = "1.0", features = ["derive"]}
 leafwing-input-manager = "0.6"
 
 leafwing_abilities_macros = { path = "macros", version = "0.1" }
+thiserror = "1.0.37"
 
 [dev-dependencies]
 bevy = {version = "0.8", default-features = false, features = ["bevy_asset", "bevy_sprite", "bevy_text", "bevy_ui", "bevy_render", "bevy_core_pipeline", "x11"]}

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -1,5 +1,11 @@
 # Release Notes
 
+## Version 0.2
+
+### Usability
+
+- All methods and functions that returned a bool now return a `Result<(), CannotUseAbility>` which explains why an action failed.
+
 ## Version 0.1
 
 ### Enhancements

--- a/examples/cooldown.rs
+++ b/examples/cooldown.rs
@@ -146,14 +146,20 @@ fn handle_double_cookies_ability(
     let mut cookie_ability_state = query.single_mut();
     // Checks whether the action is pressed, and if it is ready.
     // If so, triggers the ability, resetting its cooldown.
-    if cookie_ability_state.trigger_if_just_pressed(CookieAbility::DoubleCookies) {
+    if cookie_ability_state
+        .trigger_if_just_pressed(CookieAbility::DoubleCookies)
+        .is_ok()
+    {
         score.0 *= 2;
     }
 }
 
 fn change_cookie_color_when_clicked(mut query: Query<(&mut UiColor, AbilityState<CookieAbility>)>) {
     let (mut color, ability_state) = query.single_mut();
-    if ability_state.ready_and_just_pressed(CookieAbility::AddOne) {
+    if ability_state
+        .ready_and_just_pressed(CookieAbility::AddOne)
+        .is_ok()
+    {
         *color = CookieBundle::COOKIE_CLICKED_COLOR.into();
     }
 }

--- a/macros/Cargo.toml
+++ b/macros/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "leafwing_abilities_macros"
 description = "Macros for the `leafwing_abilities` crate"
-version = "0.1.0"
+version = "0.2.0"
 
 license = "MIT OR Apache-2.0"
 edition = "2021"

--- a/src/ability_state.rs
+++ b/src/ability_state.rs
@@ -35,27 +35,27 @@ impl<A: Abilitylike> AbilityStateItem<'_, A> {
 
     /// Is this ability both ready and pressed?
     ///
-    /// The error value for "this ability is not ready" will be prioritized over "this ability is not pressed".
+    /// The error value for "this ability is not pressed" will be prioritized over "this ability is not ready".
     #[inline]
     pub fn ready_and_pressed(&self, action: A) -> Result<(), CannotUseAbility> {
-        self.ready(action.clone())?;
-
-        match self.action_state.pressed(action) {
-            true => Ok(()),
-            false => Err(CannotUseAbility::NotPressed),
+        if self.action_state.pressed(action.clone()) {
+            self.ready(action)?;
+            Ok(())
+        } else {
+            Err(CannotUseAbility::NotPressed)
         }
     }
 
     /// Is this ability both ready and just pressed?
     ///
-    /// The error value for "this ability is not ready" will be prioritized over "this ability is not pressed".
+    /// The error value for "this ability is not pressed" will be prioritized over "this ability is not ready".
     #[inline]
     pub fn ready_and_just_pressed(&self, action: A) -> Result<(), CannotUseAbility> {
-        self.ready(action.clone())?;
-
-        match self.action_state.just_pressed(action) {
-            true => Ok(()),
-            false => Err(CannotUseAbility::NotPressed),
+        if self.action_state.just_pressed(action.clone()) {
+            self.ready(action)?;
+            Ok(())
+        } else {
+            Err(CannotUseAbility::NotPressed)
         }
     }
 
@@ -103,27 +103,27 @@ impl<A: Abilitylike> AbilityStateReadOnlyItem<'_, A> {
 
     /// Is this ability both ready and pressed?
     ///
-    /// The error value for "this ability is not ready" will be prioritized over "this ability is not pressed".
+    /// The error value for "this ability is not pressed" will be prioritized over "this ability is not ready".
     #[inline]
     pub fn ready_and_pressed(&self, action: A) -> Result<(), CannotUseAbility> {
-        self.ready(action.clone())?;
-
-        match self.action_state.pressed(action) {
-            true => Ok(()),
-            false => Err(CannotUseAbility::NotPressed),
+        if self.action_state.pressed(action.clone()) {
+            self.ready(action)?;
+            Ok(())
+        } else {
+            Err(CannotUseAbility::NotPressed)
         }
     }
 
     /// Is this ability both ready and just pressed?
     ///
-    /// The error value for "this ability is not ready" will be prioritized over "this ability is not pressed".
+    /// The error value for "this ability is not pressed" will be prioritized over "this ability is not ready".
     #[inline]
     pub fn ready_and_just_pressed(&self, action: A) -> Result<(), CannotUseAbility> {
-        self.ready(action.clone())?;
-
-        match self.action_state.just_pressed(action) {
-            true => Ok(()),
-            false => Err(CannotUseAbility::NotPressed),
+        if self.action_state.just_pressed(action.clone()) {
+            self.ready(action)?;
+            Ok(())
+        } else {
+            Err(CannotUseAbility::NotPressed)
         }
     }
 }

--- a/src/ability_state.rs
+++ b/src/ability_state.rs
@@ -1,7 +1,7 @@
 // Docs are missing from generated types :(
 #![allow(missing_docs)]
 
-use crate::{charges::ChargeState, cooldown::CooldownState, Abilitylike};
+use crate::{charges::ChargeState, cooldown::CooldownState, Abilitylike, CannotUseAbility};
 use bevy::ecs::query::WorldQuery;
 use leafwing_input_manager::action_state::ActionState;
 
@@ -29,28 +29,41 @@ impl<A: Abilitylike> AbilityStateItem<'_, A> {
     ///
     /// Calls [`Abilitylike::ready`] on the specified action.
     #[inline]
-    #[must_use]
-    pub fn ready(&self, action: A) -> bool {
+    pub fn ready(&self, action: A) -> Result<(), CannotUseAbility> {
         action.ready(&*self.charges, &*self.cooldowns)
     }
 
     /// Is this ability both ready and pressed?
+    ///
+    /// The error value for "this ability is not ready" will be prioritized over "this ability is not pressed".
     #[inline]
-    pub fn ready_and_pressed(&self, action: A) -> bool {
-        self.action_state.pressed(action.clone()) && self.ready(action)
+    pub fn ready_and_pressed(&self, action: A) -> Result<(), CannotUseAbility> {
+        self.ready(action.clone())?;
+
+        match self.action_state.pressed(action) {
+            true => Ok(()),
+            false => Err(CannotUseAbility::NotPressed),
+        }
     }
 
     /// Is this ability both ready and just pressed?
+    ///
+    /// The error value for "this ability is not ready" will be prioritized over "this ability is not pressed".
     #[inline]
-    pub fn ready_and_just_pressed(&self, action: A) -> bool {
-        self.action_state.just_pressed(action.clone()) && self.ready(action)
+    pub fn ready_and_just_pressed(&self, action: A) -> Result<(), CannotUseAbility> {
+        self.ready(action.clone())?;
+
+        match self.action_state.just_pressed(action) {
+            true => Ok(()),
+            false => Err(CannotUseAbility::NotPressed),
+        }
     }
 
     /// Triggers this ability, depleting a charge if available.
     ///
     /// Calls [`Abilitylike::trigger`] on the specified action.
     #[inline]
-    pub fn trigger(&mut self, action: A) -> bool {
+    pub fn trigger(&mut self, action: A) -> Result<(), CannotUseAbility> {
         action.trigger(&mut *self.charges, &mut *self.cooldowns)
     }
 
@@ -58,11 +71,11 @@ impl<A: Abilitylike> AbilityStateItem<'_, A> {
     ///
     /// Calls [`Abilitylike::trigger`] on the specified action.
     #[inline]
-    pub fn trigger_if_pressed(&mut self, action: A) -> bool {
+    pub fn trigger_if_pressed(&mut self, action: A) -> Result<(), CannotUseAbility> {
         if self.action_state.just_pressed(action.clone()) {
             action.trigger(&mut *self.charges, &mut *self.cooldowns)
         } else {
-            false
+            Err(CannotUseAbility::NotPressed)
         }
     }
 
@@ -70,11 +83,11 @@ impl<A: Abilitylike> AbilityStateItem<'_, A> {
     ///
     /// Calls [`Abilitylike::trigger`] on the specified action.
     #[inline]
-    pub fn trigger_if_just_pressed(&mut self, action: A) -> bool {
+    pub fn trigger_if_just_pressed(&mut self, action: A) -> Result<(), CannotUseAbility> {
         if self.action_state.just_pressed(action.clone()) {
             action.trigger(&mut *self.charges, &mut *self.cooldowns)
         } else {
-            false
+            Err(CannotUseAbility::NotPressed)
         }
     }
 }
@@ -84,21 +97,34 @@ impl<A: Abilitylike> AbilityStateReadOnlyItem<'_, A> {
     ///
     /// Calls [`Abilitylike::ready`] on the specified action.
     #[inline]
-    #[must_use]
-    pub fn ready(&self, action: A) -> bool {
+    pub fn ready(&self, action: A) -> Result<(), CannotUseAbility> {
         action.ready(self.charges, self.cooldowns)
     }
 
     /// Is this ability both ready and pressed?
+    ///
+    /// The error value for "this ability is not ready" will be prioritized over "this ability is not pressed".
     #[inline]
-    pub fn ready_and_pressed(&self, action: A) -> bool {
-        self.action_state.pressed(action.clone()) && self.ready(action)
+    pub fn ready_and_pressed(&self, action: A) -> Result<(), CannotUseAbility> {
+        self.ready(action.clone())?;
+
+        match self.action_state.pressed(action) {
+            true => Ok(()),
+            false => Err(CannotUseAbility::NotPressed),
+        }
     }
 
     /// Is this ability both ready and just pressed?
+    ///
+    /// The error value for "this ability is not ready" will be prioritized over "this ability is not pressed".
     #[inline]
-    pub fn ready_and_just_pressed(&self, action: A) -> bool {
-        self.action_state.just_pressed(action.clone()) && self.ready(action)
+    pub fn ready_and_just_pressed(&self, action: A) -> Result<(), CannotUseAbility> {
+        self.ready(action.clone())?;
+
+        match self.action_state.just_pressed(action) {
+            true => Ok(()),
+            false => Err(CannotUseAbility::NotPressed),
+        }
     }
 }
 
@@ -119,9 +145,7 @@ mod tests {
     fn ability_state_methods_are_visible_from_query() {
         fn simple_system(mut query: Query<AbilityState<TestAction>>) {
             let mut ability_state = query.single_mut();
-            if ability_state.ready(TestAction::Duck) {
-                ability_state.trigger(TestAction::Duck);
-            }
+            let _triggered = ability_state.trigger(TestAction::Duck);
         }
 
         let mut app = App::new();

--- a/src/charges.rs
+++ b/src/charges.rs
@@ -56,7 +56,7 @@ use crate::Abilitylike;
 ///
 /// // Then, you can check if an action is ready to be used
 /// // Consider using the `AbilityState` `WorldQuery` type instead for convenience!
-/// if Action::Spell.ready(&bundle.charges, &bundle.cooldowns) {
+/// if Action::Spell.ready(&bundle.charges, &bundle.cooldowns).is_ok() {
 ///     // When you use an action, remember to trigger it!
 ///     Action::Spell.trigger(&mut bundle.charges, &mut bundle.cooldowns);
 /// }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -65,10 +65,14 @@ pub trait Abilitylike: Actionlike {
     ///
     /// If this ability has charges, at least one charge must be available.
     /// If this ability has a cooldown but no charges, the cooldown must be ready.
-    /// Otherwise, returns `true`.
+    /// Otherwise, returns [`Ok(())`].
     ///
     /// Calls [`action_ready`], which can be used manually if you already know the [`Charges`] and [`Cooldown`] of interest.
-    fn ready(&self, charges: &ChargeState<Self>, cooldowns: &CooldownState<Self>) -> bool {
+    fn ready(
+        &self,
+        charges: &ChargeState<Self>,
+        cooldowns: &CooldownState<Self>,
+    ) -> Result<(), CannotUseAbility> {
         let charges = charges.get(self.clone());
         let cooldowns = cooldowns.get(self.clone());
 
@@ -85,7 +89,7 @@ pub trait Abilitylike: Actionlike {
         &self,
         charges: &mut ChargeState<Self>,
         cooldowns: &mut CooldownState<Self>,
-    ) -> bool {
+    ) -> Result<(), CannotUseAbility> {
         let charges = charges.get_mut(self.clone());
         let cooldowns = cooldowns.get_mut(self.clone());
 
@@ -96,12 +100,15 @@ pub trait Abilitylike: Actionlike {
 /// An [`Error`](std::error::Error) type that explains why an ability could not be used.
 #[derive(Error, Debug, Clone, Copy, PartialEq, Eq)]
 pub enum CannotUseAbility {
-    /// The [`Cooldown`] of this ability was not ready
+    /// TCannotUseAbilityhe [`Cooldown`] of this ability was not ready
     #[error("Cooldown not ready.")]
     OnCooldown,
     /// There were no [`Charges`] available for this ability
     #[error("No charges available.")]
     NoCharges,
+    /// The corresponding [`ActionState`](leafwing_input_manager::action_state::ActionState) was not pressed
+    #[error("The ability was not pressed.")]
+    NotPressed,
 }
 
 /// Checks if a [`Charges`], [`Cooldown`] pair associated with an action is ready to use.
@@ -110,14 +117,24 @@ pub enum CannotUseAbility {
 /// If this action has a cooldown but no charges, the cooldown must be ready.
 /// Otherwise, returns `true`.
 #[inline]
-#[must_use]
-pub fn action_ready(charges: &Option<Charges>, cooldown: &Option<Cooldown>) -> bool {
+pub fn action_ready(
+    charges: &Option<Charges>,
+    cooldown: &Option<Cooldown>,
+) -> Result<(), CannotUseAbility> {
     if let Some(charges) = charges {
-        charges.charges() > 0
+        if charges.charges() > 0 {
+            Ok(())
+        } else {
+            Err(CannotUseAbility::NoCharges)
+        }
     } else if let Some(cooldown) = cooldown {
-        cooldown.ready()
+        if cooldown.ready() {
+            Ok(())
+        } else {
+            Err(CannotUseAbility::OnCooldown)
+        }
     } else {
-        true
+        Ok(())
     }
 }
 
@@ -125,10 +142,11 @@ pub fn action_ready(charges: &Option<Charges>, cooldown: &Option<Cooldown>) -> b
 ///
 /// If no `charges` is [`None`], this will be based off the [`Cooldown`] alone, triggering it if possible.
 #[inline]
-pub fn trigger_action(charges: &mut Option<Charges>, cooldown: &mut Option<Cooldown>) -> bool {
-    if !action_ready(charges, cooldown) {
-        return false;
-    }
+pub fn trigger_action(
+    charges: &mut Option<Charges>,
+    cooldown: &mut Option<Cooldown>,
+) -> Result<(), CannotUseAbility> {
+    action_ready(charges, cooldown)?;
 
     if let Some(ref mut charges) = charges {
         charges.expend();
@@ -136,7 +154,7 @@ pub fn trigger_action(charges: &mut Option<Charges>, cooldown: &mut Option<Coold
         cooldown.trigger();
     }
 
-    true
+    Ok(())
 }
 
 /// This [`Bundle`] allows entities to manage their [`Abilitylike`] actions effectively.
@@ -168,26 +186,26 @@ mod tests {
 
     #[test]
     fn action_ready_no_cooldown_no_charges() {
-        assert!(action_ready(&None, &None));
+        assert!(action_ready(&None, &None).is_ok());
     }
 
     #[test]
     fn action_ready_just_cooldown() {
         let mut cooldown = Some(Cooldown::from_secs(1.));
-        assert!(action_ready(&None, &cooldown));
+        assert!(action_ready(&None, &cooldown).is_ok());
 
         cooldown.as_mut().map(|c| c.trigger());
-        assert!(!action_ready(&None, &cooldown));
+        assert!(action_ready(&None, &cooldown).is_err());
     }
 
     #[test]
     fn action_ready_just_charges() {
         let mut charges = Some(Charges::simple(1));
 
-        assert!(action_ready(&charges, &None));
+        assert!(action_ready(&charges, &None).is_ok());
 
         charges.as_mut().map(|c| c.expend());
-        assert!(!action_ready(&charges, &None));
+        assert!(action_ready(&charges, &None).is_err());
     }
 
     #[test]
@@ -195,47 +213,47 @@ mod tests {
         let mut charges = Some(Charges::simple(1));
         let mut cooldown = Some(Cooldown::from_secs(1.));
         // Both available
-        assert!(action_ready(&charges, &cooldown));
+        assert!(action_ready(&charges, &cooldown).is_ok());
 
-        // Charge on cooldown, cooldown ready
+        // Out of charges, cooldown ready
         charges.as_mut().map(|c| c.expend());
-        assert!(!action_ready(&charges, &cooldown));
+        assert!(action_ready(&charges, &cooldown).is_err());
 
         // Just charges
         charges.as_mut().map(|c| c.replenish());
         cooldown.as_mut().map(|c| c.trigger());
-        assert!(action_ready(&charges, &cooldown));
+        assert!(action_ready(&charges, &cooldown).is_ok());
 
         // Neither
         charges.as_mut().map(|c| c.expend());
-        assert!(!action_ready(&charges, &cooldown));
+        assert!(action_ready(&charges, &cooldown).is_err());
     }
 
     #[test]
     fn trigger_action_no_cooldown_no_charges() {
         let outcome = trigger_action(&mut None, &mut None);
-        assert!(outcome);
+        assert!(outcome.is_ok());
     }
 
     #[test]
     fn trigger_action_just_cooldown() {
         let mut cooldown = Some(Cooldown::from_secs(1.));
-        assert!(trigger_action(&mut None, &mut cooldown));
+        assert!(trigger_action(&mut None, &mut cooldown).is_ok());
 
         cooldown.as_mut().map(|c| c.trigger());
-        assert!(!trigger_action(&mut None, &mut cooldown));
-        assert!(!action_ready(&None, &cooldown));
+        assert!(trigger_action(&mut None, &mut cooldown).is_err());
+        assert!(action_ready(&None, &cooldown).is_err());
     }
 
     #[test]
     fn trigger_action_just_charges() {
         let mut charges = Some(Charges::simple(1));
 
-        assert!(trigger_action(&mut charges, &mut None));
+        assert!(trigger_action(&mut charges, &mut None).is_ok());
 
         charges.as_mut().map(|c| c.expend());
-        assert!(!trigger_action(&mut charges, &mut None));
-        assert!(!action_ready(&charges, &None));
+        assert!(trigger_action(&mut charges, &mut None).is_err());
+        assert!(action_ready(&charges, &None).is_err());
     }
 
     #[test]
@@ -243,19 +261,19 @@ mod tests {
         let mut charges = Some(Charges::simple(1));
         let mut cooldown = Some(Cooldown::from_secs(1.));
         // Both available
-        assert!(trigger_action(&mut charges, &mut cooldown));
-        assert!(!action_ready(&charges, &cooldown));
+        assert!(trigger_action(&mut charges, &mut cooldown).is_ok());
+        assert!(action_ready(&charges, &cooldown).is_err());
 
         // None available
-        assert!(!trigger_action(&mut charges, &mut cooldown));
+        assert!(trigger_action(&mut charges, &mut cooldown).is_err());
 
         // Just charges
         charges.as_mut().map(|c| c.replenish());
-        assert!(trigger_action(&mut charges, &mut cooldown));
+        assert!(trigger_action(&mut charges, &mut cooldown).is_ok());
 
         // Just cooldown
         charges.as_mut().map(|c| c.expend());
         cooldown.as_mut().map(|c| c.refresh());
-        assert!(!trigger_action(&mut charges, &mut cooldown));
+        assert!(trigger_action(&mut charges, &mut cooldown).is_err());
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,6 +8,7 @@ use bevy::ecs::prelude::*;
 use charges::{ChargeState, Charges};
 use cooldown::Cooldown;
 use leafwing_input_manager::Actionlike;
+use thiserror::Error;
 
 mod ability_state;
 pub mod charges;
@@ -90,6 +91,17 @@ pub trait Abilitylike: Actionlike {
 
         trigger_action(charges, cooldowns)
     }
+}
+
+/// An [`Error`](std::error::Error) type that explains why an ability could not be used.
+#[derive(Error, Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CannotUseAbility {
+    /// The [`Cooldown`] of this ability was not ready
+    #[error("Cooldown not ready.")]
+    OnCooldown,
+    /// There were no [`Charges`] available for this ability
+    #[error("No charges available.")]
+    NoCharges,
 }
 
 /// Checks if a [`Charges`], [`Cooldown`] pair associated with an action is ready to use.


### PR DESCRIPTION
Fixes #9.