### PR TITLE
Improve the usability of working with resource pools and the `Pool` trait

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -16,6 +16,7 @@
 - the `Pool` trait has been split in two, with the regeneration-specific mechanics handled in `RegeneratingPool`, to make the construction of non-regenerating pools much more intuitive
 - added the `Pool::is_empty` and `Pool::is_full` helper methods to the `Pool` trait
 - added `Add`, `Sub`, `AddAssign` and `SubAssign` implementations to the premade `Life` and `Mana` types and their corresponding pools
+- added the `Display` trait to `Life`, `Mana`, `LifePool` and `ManaPool`
 
 ## Version 0.5
 

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -5,6 +5,7 @@
 ### Documentation
 
 - fixed several typos (`@striezel`)
+- improved the documentation for `Pool::replenish`
 
 ### Usability
 

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -1,6 +1,15 @@
 # Release Notes
 
+## Version 0.6
+
+### Usability
+
+- removed the required `new` method from the `Pool` trait: this method was overly restrictive, and prevented the construction of more complex pools with custom initialization parameters
+  - `LifePool::new` and `ManaPool::new` methods have been added to the premade pools: do similarly for your own `Pool` types
+
 ## Version 0.5
+
+### Dependencies
 
 - now supports Bevy 0.11
 

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -2,6 +2,10 @@
 
 ## Version 0.6
 
+### Documentation
+
+- fixed several typos (`@striezel`)
+
 ### Usability
 
 - removed the required `new` method from the `Pool` trait: this method was overly restrictive, and prevented the construction of more complex pools with custom initialization parameters

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -15,6 +15,7 @@
   - the `MaxPoolLessThanZero` error type has been renamed to `MaxPoolLessThanMin` to match.
 - the `Pool` trait has been split in two, with the regeneration-specific mechanics handled in `RegeneratingPool`, to make the construction of non-regenerating pools much more intuitive
 - added the `Pool::is_empty` and `Pool::is_full` helper methods to the `Pool` trait
+- added `Add`, `Sub`, `AddAssign` and `SubAssign` implementations to the premade `Life` and `Mana` types and their corresponding pools
 
 ## Version 0.5
 

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -13,6 +13,7 @@
 - the `Pool::ZERO` associated constant has been renamed to the clearer `Pool::MIN`.
   - the `MaxPoolLessThanZero` error type has been renamed to `MaxPoolLessThanMin` to match.
 - the `Pool` trait has been split in two, with the regeneration-specific mechanics handled in `RegeneratingPool`, to make the construction of non-regenerating pools much more intuitive
+- added the `Pool::is_empty` and `Pool::is_full` helper methods to the `Pool` trait
 
 ## Version 0.5
 

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -6,6 +6,8 @@
 
 - removed the required `new` method from the `Pool` trait: this method was overly restrictive, and prevented the construction of more complex pools with custom initialization parameters
   - `LifePool::new` and `ManaPool::new` methods have been added to the premade pools: do similarly for your own `Pool` types
+- the `Pool::ZERO` associated constant has been renamed to the clearer `Pool::MIN`.
+  - the `MaxPoolLessThanZero` error type has been renamed to `MaxPoolLessThanMin` to match.
 
 ## Version 0.5
 

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -12,6 +12,7 @@
   - `LifePool::new` and `ManaPool::new` methods have been added to the premade pools: do similarly for your own `Pool` types
 - the `Pool::ZERO` associated constant has been renamed to the clearer `Pool::MIN`.
   - the `MaxPoolLessThanZero` error type has been renamed to `MaxPoolLessThanMin` to match.
+- the `Pool` trait has been split in two, with the regeneration-specific mechanics handled in `RegeneratingPool`, to make the construction of non-regenerating pools much more intuitive
 
 ## Version 0.5
 

--- a/src/ability_state.rs
+++ b/src/ability_state.rs
@@ -223,14 +223,6 @@ impl Pool for NullPool {
     type Quantity = f32;
     const ZERO: f32 = 0.0;
 
-    fn new(
-        _current: Self::Quantity,
-        _max: Self::Quantity,
-        _regen_per_second: Self::Quantity,
-    ) -> Self {
-        panic!("This type cannot be constructed.");
-    }
-
     fn current(&self) -> Self::Quantity {
         Self::ZERO
     }

--- a/src/ability_state.rs
+++ b/src/ability_state.rs
@@ -4,7 +4,7 @@
 use crate::{
     charges::ChargeState,
     cooldown::CooldownState,
-    pool::{AbilityCosts, MaxPoolLessThanZero, Pool},
+    pool::{AbilityCosts, MaxPoolLessThanMin, Pool},
     Abilitylike, CannotUseAbility,
 };
 // Required due to poor macro hygiene in `WorldQuery` macro
@@ -221,26 +221,26 @@ pub struct NullPool;
 impl Pool for NullPool {
     // So easy,
     type Quantity = f32;
-    const ZERO: f32 = 0.0;
+    const MIN: f32 = 0.0;
 
     fn current(&self) -> Self::Quantity {
-        Self::ZERO
+        Self::MIN
     }
 
     fn set_current(&mut self, _new_quantity: Self::Quantity) -> Self::Quantity {
-        Self::ZERO
+        Self::MIN
     }
 
     fn max(&self) -> Self::Quantity {
-        Self::ZERO
+        Self::MIN
     }
 
-    fn set_max(&mut self, _new_max: Self::Quantity) -> Result<(), MaxPoolLessThanZero> {
+    fn set_max(&mut self, _new_max: Self::Quantity) -> Result<(), MaxPoolLessThanMin> {
         Ok(())
     }
 
     fn regen_per_second(&self) -> Self::Quantity {
-        Self::ZERO
+        Self::MIN
     }
 
     fn set_regen_per_second(&mut self, _new_regen_per_second: Self::Quantity) {}

--- a/src/ability_state.rs
+++ b/src/ability_state.rs
@@ -219,7 +219,6 @@ mod tests {
 pub struct NullPool;
 
 impl Pool for NullPool {
-    // So easy,
     type Quantity = f32;
     const MIN: f32 = 0.0;
 

--- a/src/ability_state.rs
+++ b/src/ability_state.rs
@@ -238,10 +238,4 @@ impl Pool for NullPool {
     fn set_max(&mut self, _new_max: Self::Quantity) -> Result<(), MaxPoolLessThanMin> {
         Ok(())
     }
-
-    fn regen_per_second(&self) -> Self::Quantity {
-        Self::MIN
-    }
-
-    fn set_regen_per_second(&mut self, _new_regen_per_second: Self::Quantity) {}
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -168,7 +168,7 @@ pub fn ability_ready<P: Pool>(
         }
     // The pool does not exist, but the cost does
     } else if let Some(cost) = cost {
-        if cost > P::ZERO {
+        if cost > P::MIN {
             Err(CannotUseAbility::PoolInsufficient)
         } else {
             Ok(())

--- a/src/pool.rs
+++ b/src/pool.rs
@@ -94,7 +94,12 @@ pub trait Pool: Sized {
         let new_current = self.current() + amount;
         self.set_current(new_current);
     }
+}
 
+/// A resource pool that regenerates (or decays) over time.
+///
+/// Set the regeneration rate to a positive value to regenerate, or a negative value to decay.
+pub trait RegeneratingPool: Pool {
     /// The quantity recovered by the pool in one second.
     ///
     /// This value may be negative, in the case of automatically decaying pools (like rage).

--- a/src/pool.rs
+++ b/src/pool.rs
@@ -76,6 +76,22 @@ pub trait Pool: Sized {
     /// Returns a [`MaxPoolLessThanMin`] error if this occurs.
     fn set_max(&mut self, new_max: Self::Quantity) -> Result<(), MaxPoolLessThanMin>;
 
+    /// Is the pool currently full?
+    #[inline]
+    #[must_use]
+    fn is_full(&self) -> bool {
+        self.current() == self.max()
+    }
+
+    /// Is the pool currently empty?
+    ///
+    /// Note that this compares the current value to [`Pool::MIN`], not `0`.
+    #[inline]
+    #[must_use]
+    fn is_empty(&self) -> bool {
+        self.current() == Self::MIN
+    }
+
     /// Spend the specified amount from the pool, if there is that much available.
     ///
     /// Otherwise, return the error [`CannotUseAbility::PoolEmpty`].

--- a/src/pool.rs
+++ b/src/pool.rs
@@ -106,6 +106,8 @@ pub trait Pool: Sized {
     /// Replenish the pool by the specified amount.
     ///
     /// This cannot cause the pool to exceed maximum value that can be stored in the pool.
+    /// This is the sign-flipped counterpart to [`Self::expend`],
+    /// however, unlike [`Self::expend`], this method will not return an error if the pool is empty.
     fn replenish(&mut self, amount: Self::Quantity) {
         let new_current = self.current() + amount;
         self.set_current(new_current);

--- a/src/premade_pools.rs
+++ b/src/premade_pools.rs
@@ -3,7 +3,7 @@
 //! These can be annoying due to orphan rules that prevent you from implementing your own methods,
 //! so feel free to copy-paste them (without attribution) into your own source to make new variants.
 
-use crate::pool::{MaxPoolLessThanZero, Pool};
+use crate::pool::{MaxPoolLessThanMin, Pool};
 use bevy::prelude::{Component, Resource};
 use core::ops::{Div, Mul};
 use derive_more::{Add, AddAssign, Sub, SubAssign};
@@ -31,11 +31,12 @@ pub mod life {
         ///
         /// # Panics
         /// Panics if `current` is greater than `max`.
-        /// Panics if `current` is less than zero.
+        /// Panics if `current` or max is negative.
 
         pub fn new(current: Life, max: Life, regen_per_second: Life) -> Self {
             assert!(current <= max);
-            assert!(current >= LifePool::ZERO);
+            assert!(current >= LifePool::MIN);
+            assert!(max >= LifePool::MIN);
             Self {
                 current,
                 max,
@@ -78,7 +79,7 @@ pub mod life {
 
     impl Pool for LifePool {
         type Quantity = Life;
-        const ZERO: Life = Life(0.);
+        const MIN: Life = Life(0.);
 
         fn current(&self) -> Self::Quantity {
             self.current
@@ -94,9 +95,9 @@ pub mod life {
             self.max
         }
 
-        fn set_max(&mut self, new_max: Self::Quantity) -> Result<(), MaxPoolLessThanZero> {
-            if new_max < Self::ZERO {
-                Err(MaxPoolLessThanZero)
+        fn set_max(&mut self, new_max: Self::Quantity) -> Result<(), MaxPoolLessThanMin> {
+            if new_max < Self::MIN {
+                Err(MaxPoolLessThanMin)
             } else {
                 self.max = new_max;
                 self.set_current(self.current);
@@ -137,10 +138,11 @@ pub mod mana {
         ///
         /// # Panics
         /// Panics if `current` is greater than `max`.
-        /// Panics if `current` is less than zero.
+        /// Panics if `current` or `max` is negative.
         pub fn new(current: Mana, max: Mana, regen_per_second: Mana) -> Self {
             assert!(current <= max);
-            assert!(current >= ManaPool::ZERO);
+            assert!(current >= ManaPool::MIN);
+            assert!(max >= ManaPool::MIN);
             Self {
                 current,
                 max,
@@ -183,7 +185,7 @@ pub mod mana {
 
     impl Pool for ManaPool {
         type Quantity = Mana;
-        const ZERO: Mana = Mana(0.);
+        const MIN: Mana = Mana(0.);
 
         fn current(&self) -> Self::Quantity {
             self.current
@@ -199,9 +201,9 @@ pub mod mana {
             self.max
         }
 
-        fn set_max(&mut self, new_max: Self::Quantity) -> Result<(), MaxPoolLessThanZero> {
-            if new_max < Self::ZERO {
-                Err(MaxPoolLessThanZero)
+        fn set_max(&mut self, new_max: Self::Quantity) -> Result<(), MaxPoolLessThanMin> {
+            if new_max < Self::MIN {
+                Err(MaxPoolLessThanMin)
             } else {
                 self.max = new_max;
                 self.set_current(self.current);

--- a/src/premade_pools.rs
+++ b/src/premade_pools.rs
@@ -5,7 +5,7 @@
 
 use crate::pool::{MaxPoolLessThanMin, Pool};
 use bevy::prelude::{Component, Resource};
-use core::ops::{Div, Mul};
+use core::ops::{Add, AddAssign, Div, Mul, Sub, SubAssign};
 use derive_more::{Add, AddAssign, Sub, SubAssign};
 
 /// A premade resource pool for life (aka health, hit points or HP).
@@ -117,6 +117,36 @@ pub mod life {
             self.regen_per_second = new_regen_per_second;
         }
     }
+
+    impl Add<Life> for LifePool {
+        type Output = Self;
+
+        fn add(mut self, rhs: Life) -> Self::Output {
+            self.set_current(self.current + rhs);
+            self
+        }
+    }
+
+    impl Sub<Life> for LifePool {
+        type Output = Self;
+
+        fn sub(mut self, rhs: Life) -> Self::Output {
+            self.set_current(self.current - rhs);
+            self
+        }
+    }
+
+    impl AddAssign<Life> for LifePool {
+        fn add_assign(&mut self, rhs: Life) {
+            self.set_current(self.current + rhs);
+        }
+    }
+
+    impl SubAssign<Life> for LifePool {
+        fn sub_assign(&mut self, rhs: Life) {
+            self.set_current(self.current - rhs);
+        }
+    }
 }
 
 /// A premade resource pool for mana (aka MP).
@@ -225,6 +255,36 @@ pub mod mana {
 
         fn set_regen_per_second(&mut self, new_regen_per_second: Self::Quantity) {
             self.regen_per_second = new_regen_per_second;
+        }
+    }
+
+    impl Add<Mana> for ManaPool {
+        type Output = Self;
+
+        fn add(mut self, rhs: Mana) -> Self::Output {
+            self.set_current(self.current + rhs);
+            self
+        }
+    }
+
+    impl Sub<Mana> for ManaPool {
+        type Output = Self;
+
+        fn sub(mut self, rhs: Mana) -> Self::Output {
+            self.set_current(self.current - rhs);
+            self
+        }
+    }
+
+    impl AddAssign<Mana> for ManaPool {
+        fn add_assign(&mut self, rhs: Mana) {
+            self.set_current(self.current + rhs);
+        }
+    }
+
+    impl SubAssign<Mana> for ManaPool {
+        fn sub_assign(&mut self, rhs: Mana) {
+            self.set_current(self.current - rhs);
         }
     }
 }

--- a/src/premade_pools.rs
+++ b/src/premade_pools.rs
@@ -5,6 +5,7 @@
 
 use crate::pool::{MaxPoolLessThanMin, Pool};
 use bevy::prelude::{Component, Resource};
+use core::fmt::{Display, Formatter};
 use core::ops::{Add, AddAssign, Div, Mul, Sub, SubAssign};
 use derive_more::{Add, AddAssign, Sub, SubAssign};
 
@@ -147,6 +148,18 @@ pub mod life {
             self.set_current(self.current - rhs);
         }
     }
+
+    impl Display for Life {
+        fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
+            write!(f, "{}", self.0)
+        }
+    }
+
+    impl Display for LifePool {
+        fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
+            write!(f, "{}/{}", self.current, self.max)
+        }
+    }
 }
 
 /// A premade resource pool for mana (aka MP).
@@ -285,6 +298,18 @@ pub mod mana {
     impl SubAssign<Mana> for ManaPool {
         fn sub_assign(&mut self, rhs: Mana) {
             self.set_current(self.current - rhs);
+        }
+    }
+
+    impl Display for Mana {
+        fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
+            write!(f, "{}", self.0)
+        }
+    }
+
+    impl Display for ManaPool {
+        fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
+            write!(f, "{}/{}", self.current, self.max)
         }
     }
 }

--- a/src/premade_pools.rs
+++ b/src/premade_pools.rs
@@ -10,6 +10,8 @@ use derive_more::{Add, AddAssign, Sub, SubAssign};
 
 /// A premade resource pool for life (aka health, hit points or HP).
 pub mod life {
+    use crate::pool::RegeneratingPool;
+
     use super::*;
 
     /// The amount of life available to a unit.
@@ -104,7 +106,9 @@ pub mod life {
                 Ok(())
             }
         }
+    }
 
+    impl RegeneratingPool for LifePool {
         fn regen_per_second(&self) -> Self::Quantity {
             self.regen_per_second
         }
@@ -117,6 +121,8 @@ pub mod life {
 
 /// A premade resource pool for mana (aka MP).
 pub mod mana {
+    use crate::pool::RegeneratingPool;
+
     use super::*;
 
     /// The amount of mana available to a unit.
@@ -210,7 +216,9 @@ pub mod mana {
                 Ok(())
             }
         }
+    }
 
+    impl RegeneratingPool for ManaPool {
         fn regen_per_second(&self) -> Self::Quantity {
             self.regen_per_second
         }

--- a/src/premade_pools.rs
+++ b/src/premade_pools.rs
@@ -26,6 +26,24 @@ pub mod life {
         pub regen_per_second: Life,
     }
 
+    impl LifePool {
+        /// Creates a new [`LifePool`] with the supplied settings.
+        ///
+        /// # Panics
+        /// Panics if `current` is greater than `max`.
+        /// Panics if `current` is less than zero.
+
+        pub fn new(current: Life, max: Life, regen_per_second: Life) -> Self {
+            assert!(current <= max);
+            assert!(current >= LifePool::ZERO);
+            Self {
+                current,
+                max,
+                regen_per_second,
+            }
+        }
+    }
+
     /// A quantity of life, used to modify a [`LifePool`].
     ///
     /// This can be used for damage computations, life regeneration, healing and so on.
@@ -61,18 +79,6 @@ pub mod life {
     impl Pool for LifePool {
         type Quantity = Life;
         const ZERO: Life = Life(0.);
-
-        fn new(
-            current: Self::Quantity,
-            max: Self::Quantity,
-            regen_per_second: Self::Quantity,
-        ) -> Self {
-            LifePool {
-                current,
-                max,
-                regen_per_second,
-            }
-        }
 
         fn current(&self) -> Self::Quantity {
             self.current
@@ -126,6 +132,23 @@ pub mod mana {
         pub regen_per_second: Mana,
     }
 
+    impl ManaPool {
+        /// Creates a new [`ManaPool`] with the supplied settings.
+        ///
+        /// # Panics
+        /// Panics if `current` is greater than `max`.
+        /// Panics if `current` is less than zero.
+        pub fn new(current: Mana, max: Mana, regen_per_second: Mana) -> Self {
+            assert!(current <= max);
+            assert!(current >= ManaPool::ZERO);
+            Self {
+                current,
+                max,
+                regen_per_second,
+            }
+        }
+    }
+
     /// A quantity of mana, used to modify a [`ManaPool`].
     ///
     /// This can be used for ability costs, mana regeneration and so on.
@@ -161,18 +184,6 @@ pub mod mana {
     impl Pool for ManaPool {
         type Quantity = Mana;
         const ZERO: Mana = Mana(0.);
-
-        fn new(
-            current: Self::Quantity,
-            max: Self::Quantity,
-            regen_per_second: Self::Quantity,
-        ) -> Self {
-            ManaPool {
-                current,
-                max,
-                regen_per_second,
-            }
-        }
 
         fn current(&self) -> Self::Quantity {
             self.current

--- a/src/premade_pools.rs
+++ b/src/premade_pools.rs
@@ -80,6 +80,14 @@ pub mod life {
         }
     }
 
+    impl Div<Life> for Life {
+        type Output = f32;
+
+        fn div(self, rhs: Life) -> f32 {
+            self.0 / rhs.0
+        }
+    }
+
     impl Pool for LifePool {
         type Quantity = Life;
         const MIN: Life = Life(0.);
@@ -229,6 +237,14 @@ pub mod mana {
 
         fn div(self, rhs: f32) -> Mana {
             Mana(self.0 / rhs)
+        }
+    }
+
+    impl Div<Mana> for Mana {
+        type Output = f32;
+
+        fn div(self, rhs: Mana) -> f32 {
+            self.0 / rhs.0
         }
     }
 

--- a/src/systems.rs
+++ b/src/systems.rs
@@ -1,6 +1,6 @@
 //! The systems that power each [`InputManagerPlugin`](crate::plugin::InputManagerPlugin).
 
-use crate::pool::Pool;
+use crate::pool::RegeneratingPool;
 use crate::{charges::ChargeState, cooldown::CooldownState, Abilitylike};
 
 use bevy::ecs::prelude::*;
@@ -37,7 +37,7 @@ pub fn tick_cooldowns<A: Abilitylike>(
 }
 
 /// Regenerates the resource of the [`Pool`] type `P` based on the elapsed [`Time`].
-pub fn regenerate_resource_pool<P: Pool + Component + Resource>(
+pub fn regenerate_resource_pool<P: RegeneratingPool + Component + Resource>(
     mut query: Query<&mut P>,
     pool_res: Option<ResMut<P>>,
     time: Res<Time>,


### PR DESCRIPTION
See `CHANGELOG.md` for changes made.

Unfortunately orphan rules greatly restrict our ability to implement a lot of these improvements for *all* pool types, so we're left with examples to copy-paste.