### PR TITLE
Update for Bevy 0.12

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,19 +23,19 @@ default = ["premade_pools"]
 premade_pools = []
 
 [dependencies]
-bevy = { version = "0.11", default-features = false, features = [
+bevy = { version = "0.12", default-features = false, features = [
 	"serialize",
 	"bevy_gilrs",
 ] }
 serde = { version = "1.0", features = ["derive"] }
-leafwing-input-manager = "0.10"
+leafwing-input-manager = "0.11"
 
 leafwing_abilities_macros = { path = "macros", version = "0.3" }
 thiserror = "1.0.37"
 derive_more = "0.99.17"
 
 [dev-dependencies]
-bevy = { version = "0.11", default-features = false, features = [
+bevy = { version = "0.12", default-features = false, features = [
 	"bevy_asset",
 	"bevy_sprite",
 	"bevy_text",

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ impl Default for ZyraBundle {
         ZyraBundle {
             champion: Zyra,
             // Max life, then regen
-            life_pool: LifePool::new_full(Life(574.), (Life(5.5))),
+            life_pool: LifePool::new(Life(574.), Life(574.), (Life(5.5))),
             input_manager_bundle: InputManagerBundle::<ZyraAbility> {
                 input_map: ZyraAbility::input_map(),
                 ..default()
@@ -109,7 +109,7 @@ impl Default for ZyraBundle {
                 charges: ZyraAbility::charges(),
             },
             mana_bundle: PoolBundle::<ZyraAbility, ManaPool> {
-                pool: ManaPool::new_full(Mana(418.), Mana(13.0)),
+                pool: ManaPool::new(Mana(418.), Mana(418.), Mana(13.0)),
                 ability_costs: ZyraAbility::mana_costs(),
             }
         }

--- a/src/charges.rs
+++ b/src/charges.rs
@@ -67,8 +67,8 @@ use crate::{Abilitylike, CannotUseAbility};
 /// // You can also define resource pools using a separate bundle.
 /// // Typically, you'll want to nest both of these bundles under a custom Bundle type for your characters.
 /// let mut mana_bundle = PoolBundle {
-///     // Max mana of 1000., regen rate of 10.
-///     pool: ManaPool::new_full(Mana(100.0), Mana(1.0)),
+///     // Max mana of 100., regen rate of 1.
+///     pool: ManaPool::new(Mana(100.0), Mana(100.0), Mana(1.0)),
 ///     ability_costs: Action::mana_costs(),     
 /// };
 ///

--- a/tests/cooldowns.rs
+++ b/tests/cooldowns.rs
@@ -228,7 +228,7 @@ fn global_cooldown_overrides_short_cooldowns() {
     );
 
     // Let per-action cooldown elapse
-    sleep(Duration::from_millis(200));
+    sleep(Duration::from_millis(250));
     app.update();
 
     let cooldowns: &CooldownState<Action> = app.world.resource();
@@ -238,7 +238,7 @@ fn global_cooldown_overrides_short_cooldowns() {
     );
 
     // Wait for full GCD to expire
-    sleep(Duration::from_millis(400));
+    sleep(Duration::from_millis(250));
     app.update();
 
     let cooldowns: &CooldownState<Action> = app.world.resource();


### PR DESCRIPTION
Updates deprecated `Pool` code in some docs, bumps Bevy version to 0.12, and updates the cooldown test to limit thread sleeps to `Time::max_delta`.