### PR TITLE
Update for Bevy 0.15

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "leafwing_abilities"
 description = "A convenient, well-tested ability management suite. Built for the Bevy game engine."
-version = "0.9.0"
+version = "0.10.0"
 authors = ["Leafwing Studios"]
 homepage = "https://leafwing-studios.com/"
 repository = "https://github.com/leafwing-studios/leafwing_abilities"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ default = ["premade_pools"]
 premade_pools = []
 
 [dependencies]
-bevy = { version = "0.14", default-features = false, features = [
+bevy = { version = "0.15", default-features = false, features = [
 	"serialize",
 	"bevy_gilrs",
 ] }
@@ -35,7 +35,7 @@ thiserror = "1.0.37"
 derive_more = "0.99.17"
 
 [dev-dependencies]
-bevy = { version = "0.14", default-features = false, features = [
+bevy = { version = "0.15", default-features = false, features = [
 	"bevy_asset",
 	"bevy_sprite",
 	"bevy_text",
@@ -44,6 +44,11 @@ bevy = { version = "0.14", default-features = false, features = [
 	"bevy_core_pipeline",
 	"x11",
 	"default_font",
+	"bevy_window",        #Bugfix See: https://github.com/bevyengine/bevy/issues/16568
 ] }
 # Needed to provide implementations for standard input devices
 leafwing-input-manager = { version = "0.15", default-features = true }
+
+#TODO: remove when leafwing-input-manager 0.15 is published
+[patch.crates-io]
+leafwing-input-manager = { git = "https://github.com/pcwalton/leafwing-input-manager.git", branch = "0.15-newer" }

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ use leafwing_input_manager::prelude::*;
 
 // We're modelling https://leagueoflegends.fandom.com/wiki/Zyra/LoL
 // to show off this crate's features!
-#[derive(Actionlike, Abilitylike, Clone, Copy, Hash, PartialEq, Eq, Reflect)]
+#[derive(Actionlike, Abilitylike, Clone, Copy, Hash, PartialEq, Eq, Reflect, Debug)]
 pub enum ZyraAbility {
     GardenOfThorns,
     DeadlySpines,

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -1,5 +1,9 @@
 # Release Notes
 
+## Version 0.8
+
+- now supports Bevy 0.15
+
 ## Version 0.9
 
 ## Dependencies (0.9)

--- a/examples/cooldown.rs
+++ b/examples/cooldown.rs
@@ -74,7 +74,9 @@ struct Cookie;
 #[derive(Bundle)]
 struct CookieBundle {
     cookie: Cookie,
-    button_bundle: ButtonBundle,
+    button: Button,
+    node: Node,
+    background_color: BackgroundColor,
     abilities_bundle: AbilitiesBundle<CookieAbility>,
     input_manager_bundle: InputManagerBundle<CookieAbility>,
 }
@@ -87,15 +89,13 @@ impl CookieBundle {
     fn new() -> CookieBundle {
         CookieBundle {
             cookie: Cookie,
-            button_bundle: ButtonBundle {
-                style: Style {
-                    height: Val::Px(100.),
-                    width: Val::Px(100.),
-                    ..Default::default()
-                },
-                background_color: BackgroundColor(Self::COOKIE_COLOR.into()),
-                ..default()
+            button: Button,
+            node: Node {
+                height: Val::Px(100.),
+                width: Val::Px(100.),
+                ..Default::default()
             },
+            background_color: BackgroundColor(Self::COOKIE_COLOR.into()),
             abilities_bundle: AbilitiesBundle {
                 cooldowns: CookieAbility::cooldowns(),
                 ..default()
@@ -113,7 +113,7 @@ fn spawn_cookie(mut commands: Commands) {
 }
 
 fn spawn_camera(mut commands: Commands) {
-    commands.spawn(Camera2dBundle::default());
+    commands.spawn(Camera2d);
 }
 
 // We need a huge amount of space to be able to let you play this game for long enough ;)
@@ -188,13 +188,13 @@ struct ScoreText;
 
 fn spawn_score_text(mut commands: Commands) {
     commands
-        .spawn(TextBundle::from_section(
-            "Score: ",
-            TextStyle {
+        .spawn((
+            Text::new("Score: "),
+            TextFont {
                 font_size: 50.,
-                color: Color::WHITE,
                 ..Default::default()
             },
+            TextColor(Color::WHITE),
         ))
         .insert(ScoreText);
 }
@@ -202,5 +202,5 @@ fn spawn_score_text(mut commands: Commands) {
 fn display_score(score: Res<Score>, mut query: Query<&mut Text, With<ScoreText>>) {
     let score = score.0;
     let mut text = query.single_mut();
-    text.sections[0].value = format!("Score: {score}");
+    text.0 = format!("Score: {score}");
 }

--- a/examples/cooldown.rs
+++ b/examples/cooldown.rs
@@ -126,6 +126,8 @@ fn cookie_clicked(mut query: Query<(&Interaction, &mut ActionState<CookieAbility
     // by allowing you to hook into the ability state.
     if *cookie_interaction == Interaction::Pressed {
         cookie_action_state.press(&CookieAbility::AddOne);
+    } else {
+        cookie_action_state.release(&CookieAbility::AddOne);
     }
 }
 

--- a/src/charges.rs
+++ b/src/charges.rs
@@ -21,7 +21,7 @@ use std::collections::HashMap;
 /// use leafwing_abilities::premade_pools::mana::{Mana, ManaPool};
 /// use leafwing_input_manager::Actionlike;
 ///
-/// #[derive(Actionlike, Abilitylike, Clone, Reflect, Hash, PartialEq, Eq)]
+/// #[derive(Actionlike, Abilitylike, Clone, Reflect, Hash, PartialEq, Eq, Debug)]
 /// enum Action {
 ///     // Neither cooldowns nor charges
 ///     Move,
@@ -163,7 +163,7 @@ impl<A: Abilitylike> ChargeState<A> {
     /// use leafwing_abilities::prelude::*;
     /// use leafwing_input_manager::Actionlike;
     ///
-    /// #[derive(Actionlike, Abilitylike, Clone, Copy, PartialEq, Eq, Hash, Reflect)]
+    /// #[derive(Actionlike, Abilitylike, Clone, Copy, PartialEq, Eq, Hash, Reflect, Debug)]
     /// enum Action {
     ///     Run,
     ///     Jump,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -52,7 +52,7 @@ pub mod prelude {
 /// use leafwing_input_manager::Actionlike;
 /// use bevy::reflect::Reflect;
 ///
-/// #[derive(Actionlike, PartialEq, Eq, Clone, Copy, Hash, Reflect)]
+/// #[derive(Actionlike, PartialEq, Eq, Clone, Copy, Hash, Reflect, Debug)]
 /// enum PlayerAction {
 ///    // Movement
 ///    Up,


### PR DESCRIPTION
Support bevy 0.15
I have not changed any Bundles over to using required components, as it is not strictly necessary for 0.15 support

This depends on https://github.com/Leafwing-Studios/leafwing-input-manager/pull/644

Notes:
- Doctests and examples were broken on main, so I fixed those so I could verify my changes. Let me know if you'd like a separate PR for those changes.
- examples/cooldown.rs is using crlf line endings for some reason? presumably not intended?  I've left the line endings as is for this PR, so it doesn't look like i've changed the  whole file when reviewing etc.
- The examples are affected by this issue https://github.com/bevyengine/bevy/issues/16568, so I have added an extra entry to the bevy features in `dev-dependencies` with a comment