### PR TITLE
Update tools/ci to use newer xshell

### DIFF
--- a/macros/src/abilitylike.rs
+++ b/macros/src/abilitylike.rs
@@ -7,7 +7,6 @@ use syn::{DeriveInput, Ident};
 /// This approach and implementation is inspired by the `strum` crate,
 /// Copyright (c) 2019 Peter Glotfelty
 /// available under the MIT License at https://github.com/Peternator7/strum
-
 pub(crate) fn abilitylike_inner(ast: &DeriveInput) -> TokenStream {
     // Splitting the abstract syntax tree
     let enum_name = &ast.ident;

--- a/src/premade_pools.rs
+++ b/src/premade_pools.rs
@@ -37,7 +37,6 @@ pub mod life {
         /// # Panics
         /// Panics if `current` is greater than `max`.
         /// Panics if `current` or max is negative.
-
         pub fn new(current: Life, max: Life, regen_per_second: Life) -> Self {
             assert!(current <= max);
             assert!(current >= LifePool::MIN);

--- a/tools/ci/Cargo.toml
+++ b/tools/ci/Cargo.toml
@@ -6,4 +6,4 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-xshell = "0.1"
+xshell = "0.2"

--- a/tools/ci/src/main.rs
+++ b/tools/ci/src/main.rs
@@ -1,4 +1,4 @@
-use xshell::cmd;
+use xshell::{cmd, Shell};
 
 fn main() {
     // When run locally, results may differ from actual CI runs triggered by
@@ -6,29 +6,37 @@ fn main() {
     // - Official CI runs latest stable
     // - Local runs use whatever the default Rust is locally
 
+    let sh = Shell::new().unwrap();
+
     // See if any code needs to be formatted
-    cmd!("cargo fmt --all -- --check")
+    cmd!(sh, "cargo fmt --all -- --check")
         .run()
         .expect("Please run `cargo fmt --all` to format your code.");
 
     // See if clippy has any complaints.
     // - Type complexity must be ignored because we use huge templates for queries
-    cmd!("cargo clippy --workspace --all-features -- -D warnings -A clippy::type_complexity")
-        .run()
-        .expect("Please fix `cargo clippy` errors with all features enabled.");
+    cmd!(
+        sh,
+        "cargo clippy --workspace --all-features -- -D warnings -A clippy::type_complexity"
+    )
+    .run()
+    .expect("Please fix `cargo clippy` errors with all features enabled.");
 
     // Check for errors with no features enabled
-    cmd!("cargo check --workspace --no-default-features")
+    cmd!(sh, "cargo check --workspace --no-default-features")
         .run()
         .expect("Please fix `cargo check` errors with no features enabled .");
 
     // Check for errors with default features enabled
-    cmd!("cargo check --workspace")
+    cmd!(sh, "cargo check --workspace")
         .run()
         .expect("Please fix `cargo check` errors with default features enabled.");
 
     // Check the examples with clippy
-    cmd!("cargo clippy --examples -- -D warnings -A clippy::type_complexity")
-        .run()
-        .expect("Please fix `cargo clippy` errors for the examples.");
+    cmd!(
+        sh,
+        "cargo clippy --examples -- -D warnings -A clippy::type_complexity"
+    )
+    .run()
+    .expect("Please fix `cargo clippy` errors for the examples.");
 }


### PR DESCRIPTION
Update tools/ci to use newer xshell

Xshell 1.0 does not compile with nightly rust, and *may* not be comatible with upcoming stable rust versions (See https://github.com/matklad/xshell/pull/97). This was fixed in xshell 0.2.7

I noticed this while working on #68. This also includes the clippy lint fixes from #68 so it actually passes CI.